### PR TITLE
Adds battery watcher to app

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -88,4 +88,5 @@
     <plugin name="cordova-plugin-statusbar" spec="^2.4.2" />
     <engine name="android" spec="~7.0.0" />
     <plugin name="cordova-sqlite-storage" spec="^2.3.2" />
+    <plugin name="cordova-plugin-battery-status" spec="^2.0.2" />
 </widget>

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,6 +99,11 @@
         "tslib": "^1.7.1"
       }
     },
+    "@ionic-native/battery-status": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@ionic-native/battery-status/-/battery-status-4.9.0.tgz",
+      "integrity": "sha512-xSWBF8ApceoQQqxTrs1xEgvCzKpVW/A2R+15SPaIiR3LSqmfWSLOOXU6O7sHLyeLsKP1Sxq31mcVIfaBSQM1EA=="
+    },
     "@ionic-native/core": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@ionic-native/core/-/core-4.7.0.tgz",
@@ -1334,6 +1339,11 @@
       "version": "0.8.7",
       "resolved": "https://registry.npmjs.org/cordova-plugin-badge/-/cordova-plugin-badge-0.8.7.tgz",
       "integrity": "sha512-s+s4yusKdeJ4sMPhQs4zR3lR2UuROzSy14GFAp00pTHPiBfCtxeINSUYAZYnpuO3RGx6PPlVCwSJpVG0IdM58g=="
+    },
+    "cordova-plugin-battery-status": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-battery-status/-/cordova-plugin-battery-status-2.0.2.tgz",
+      "integrity": "sha1-OqGR97y2/Hz8nd/t9h5rSgWy31U="
     },
     "cordova-plugin-device": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@angular/http": "5.2.10",
     "@angular/platform-browser": "5.2.10",
     "@angular/platform-browser-dynamic": "5.2.10",
+    "@ionic-native/battery-status": "^4.9.0",
     "@ionic-native/core": "4.7.0",
     "@ionic-native/geolocation": "^4.7.0",
     "@ionic-native/local-notifications": "^4.8.0",
@@ -29,6 +30,7 @@
     "@ionic/storage": "2.1.3",
     "cordova-android": "^7.1.0",
     "cordova-plugin-badge": "^0.8.7",
+    "cordova-plugin-battery-status": "^2.0.2",
     "cordova-plugin-device": "^2.0.2",
     "cordova-plugin-geolocation": "^4.0.1",
     "cordova-plugin-ionic-keyboard": "^2.1.2",
@@ -62,7 +64,8 @@
       "cordova-plugin-ionic-keyboard": {},
       "cordova-plugin-local-notification": {},
       "cordova-plugin-statusbar": {},
-      "cordova-sqlite-storage": {}
+      "cordova-sqlite-storage": {},
+      "cordova-plugin-battery-status": {}
     },
     "platforms": [
       "android"

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -25,6 +25,7 @@ import { OccurrenceServiceProvider } from '../providers/occurrence-service/occur
 import { LocalNotifications } from '@ionic-native/local-notifications';
 import { SuperTabsModule } from 'ionic2-super-tabs';
 import { ConfirmationTaskPage } from '../pages/confirmation-task/confirmation-task';
+import { BatteryStatus } from '@ionic-native/battery-status';
 @NgModule({
   declarations: [
     MyApp,
@@ -69,8 +70,8 @@ import { ConfirmationTaskPage } from '../pages/confirmation-task/confirmation-ta
     ItineraryServiceProvider,
     PersistenceServiceProvider,
     OccurrenceServiceProvider,
-    LocalNotifications
-   
+    LocalNotifications,
+    BatteryStatus
   ]
 })
 export class AppModule {}


### PR DESCRIPTION
The dependency ionic-native/battery-status was added
See https://ionicframework.com/docs/native/battery-status/ for more details.

A battery status watcher was added on `app.component.ts` file. It starts watching on app initialization.

Note 1: This commit add a new dependency, so it's necessary to run `npm install` 
Note 2: I added a toast to show the battery status only for debug purpose.